### PR TITLE
Disable doclint in Java 8 builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.liveramp</groupId>
@@ -66,6 +66,18 @@
     </dependency>
   </dependencies>
 
+  <profiles>
+    <profile>
+      <id>doclint-java8-disable</id>
+      <activation>
+        <jdk>[1.8,)</jdk>
+      </activation>
+      <properties>
+        <javadoc.opts>-Xdoclint:none</javadoc.opts>
+      </properties>
+    </profile>
+  </profiles>
+
   <build>
     <plugins>
 
@@ -113,6 +125,9 @@
         <executions>
           <execution>
             <id>attach-javadocs</id>
+            <configuration>
+              <additionalparam>${javadoc.opts}</additionalparam>
+            </configuration>
             <phase>package</phase>
             <goals>
               <goal>jar</goal>


### PR DESCRIPTION
Doclint is an exceptionally new feature in Java 8 that causes javadoc
generation to produce an error any time it encounters invalid javadoc
syntax. Unfortunately, if your javadocs are not properly doclint-compliant
(like ours), this will cause generating javadocs, and anything that depends
on it, i.e. `mvn install` to fail with a large number of javadoc errors.
Unless we want to write a very large amount of javadoc information, we
should disable doclint for now. This change is set up so that it will
add the flag to disable doclint, only for Java 8, for Java 7, this will
allow build to continue without any problems.

@bpodgursky 
