### PR TITLE
Bump version of pom-common to 1.1-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.liveramp</groupId>
   <artifactId>pom-common</artifactId>
-  <version>1.0-SNAPSHOT</version>
+  <version>1.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>pom-common</name>


### PR DESCRIPTION
1.1 is now the Java 8 version. Java 7 will be released under 1.0
for backwards compatibility. Moving forward, new builds will be
released for Java 8.

@bpodgursky 