### PR TITLE
version 1.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>com.liveramp</groupId>
   <artifactId>pom-common</artifactId>
-  <version>1.1-SNAPSHOT</version>
+  <version>1.6-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>pom-common</name>
@@ -11,9 +11,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <!--Need to be set in settings.xml to deploy artifacts-->
-    <!--<gpg.keyname>""</gpg.keyname>-->
-    <!--<gpg.passphrase>""</gpg.passphrase>-->
+    <!--GPG keyname and passphrase need to be set in settings.xml to deploy artifacts-->
   </properties>
 
   <scm>


### PR DESCRIPTION
Mostly doing this to release a pom version to Central which doesn't have the `gpg.passphrase` and `gpg.keyname` properties defined.